### PR TITLE
fix the etc for the backup program

### DIFF
--- a/desietc/etc.py
+++ b/desietc/etc.py
@@ -1049,7 +1049,7 @@ class ETCAlgorithm(object):
             Ebv = 0.
             logging.warning('Seting Ebv=0 since no non-sky targets found.')
         # Calculate the corresponding MW transparency factor unless this is the backup program.
-        if self.fassign_data['FAPRGRM'] != 'BACKUP':
+        if self.fassign_data['FAPRGRM'] != 'backup':
             MW_transp = 10 ** (-self.Ebv_coef * Ebv / 2.5)
         else:
             MW_transp = 1.


### PR DESCRIPTION
Thanks to @dkirkby @schlafly (in https://github.com/desihub/desispec/pull/2370 )  I was able to run ETC on an exposure, and 
looking at the json allowed to me figure out why the backup program switch doesn't trigger.
The check was written as 
https://github.com/desihub/desietc/blob/c668ed839e97105e5b5b0d0d38b01f02e8afb19c/desietc/etc.py#L1052
 FAPRGRM !='BACKUP' while it's actually is 'backup'  :) 

This patch fixes that. 

I checked that for the exposure 252068 before the etc was returning :
 "MW_transp": 0.613693618072619
while with the patch it does
 "MW_transp": 1
